### PR TITLE
Link to the server in guide detail footer.

### DIFF
--- a/guides/templates/guides/guide_detail.html
+++ b/guides/templates/guides/guide_detail.html
@@ -56,4 +56,6 @@
   <article>
     {{ guide.content }}
   </article>
+  <br>
+  <i class="muted">Want to talk to <strong>{{ guide.author.first_name }}</strong> about this article? Come <a href="https://discord.gg/010z0Kw1A9ql5c1Qe">join us</a>!</i>
 {% endblock %}


### PR DESCRIPTION
as @robstolarz suggested, this adds a link in the footer of guides with a link to the server:
![image](https://user-images.githubusercontent.com/22679924/39773177-893d6252-52f7-11e8-90d3-642bb22f8818.png)
