### PR TITLE
Fix navbar wrapping on mobile

### DIFF
--- a/website/static/css/base.css
+++ b/website/static/css/base.css
@@ -9,3 +9,21 @@ html {
     -moz-osx-font-smoothing: grayscale;
     background-color: #d0d0d0;
 }
+
+.navbar {
+    display: flex;
+}
+
+.nav-title {
+    margin-right: auto;
+}
+
+.nav-link {
+    margin-left: 1em;
+    margin-right: 1em;
+    font-weight: bolder;
+}
+
+a {
+    text-decoration: none;
+}

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -20,25 +20,21 @@
 </head>
 
 <body class="max-w-big push-center">
-<nav class="row">
-  <div class="col col-2">
-    <code class="monospace label text-left">
-      {% if request.user.is_authenticated %}
-        {# If the user has their Discord account connected, show that #}
-        <a class="black strong" href="{% url 'profiles:detail' user.id %}">{{ request.user.first_name }}</a>@programming$
-      {% else %}
-        {# If the user is not logged in, provide a link to Discord OAuth #}
-        <a class="black strong" href="{% provider_login_url 'discord' next='/' %}">$(YOUR_NAME)</a>@programming$
-      {% endif %}
-    </code>
-  </div>
-  <div class="col push-center">
-    <a href="{% url 'home:index' %}">Home</a>
-    &nbsp;
-    <a href="{% url 'guides:index' %}">Guides</a>
-    &nbsp;
-    <a href="{% url 'stats:index' %}">Statistics</a>
-  </div>
+<nav class="navbar">
+  <code class="nav-title monospace label text-left">
+    {% if request.user.is_authenticated %}
+      {# If the user has their Discord account connected, show that #}
+      <a class="black strong" href="{% url 'profiles:detail' user.id %}">{{ request.user.first_name }}</a>@programming$
+    {% else %}
+      {# If the user is not logged in, provide a link to Discord OAuth #}
+      <a class="black strong" href="{% provider_login_url 'discord' next='/' %}">$(YOUR_NAME)</a>@programming$
+    {% endif %}
+  </code>
+  <a class="nav-link" href="{% url 'home:index' %}">Home</a>
+  &nbsp;
+  <a class="nav-link" href="{% url 'guides:index' %}">Guides</a>
+  &nbsp;
+  <a class="nav-link" href="{% url 'stats:index' %}">Stats</a>
 </nav>
 {% if messages %}
   {% for message in messages %}


### PR DESCRIPTION
previously, the navbar would wrap to the next line on mobile, which would look pretty badly. with this PR, the navbar now uses flexbox to ensure that doesnt happen, because using row layout for the navbar was a questionable decision in the first place.

also, this removes the underline from links in the navbar and makes the text a bit **bolder**.
screenshot on very narrow browser window: 
![image](https://user-images.githubusercontent.com/22679924/40023903-d3c70330-57cc-11e8-8c8a-6c0319fb6057.png)
