### PR TITLE
Account deletion view (GDPR §17)

### DIFF
--- a/profiles/templates/auth/user_confirm_delete.html
+++ b/profiles/templates/auth/user_confirm_delete.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+
+{% block body %}
+  <br>
+  <h2>Account deletion confirmation</h2>
+  <form method="post">
+    {% csrf_token %}
+    <p>Are you sure you want to permanently delete your account?</p>
+    {% if request.user.guides %}
+      <b>This will also permanently delete your following guides:</b>
+      <ul>
+        {% for guide in request.user.guides %}
+          <li><a href="{% url 'guides:detail' guide.id %}">{{ guide.title }}</a></li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+    <div class="row align-right">
+      <a href="javascript:history.go(-1)" class="button col outline">No, take me back</a>
+      <input type="submit" class="button col" value="Yes, delete it" />
+    </div>
+  </form>
+{% endblock %}

--- a/profiles/templates/auth/user_confirm_delete.html
+++ b/profiles/templates/auth/user_confirm_delete.html
@@ -6,14 +6,14 @@
   <form method="post">
     {% csrf_token %}
     <p>Are you sure you want to permanently delete your account?</p>
-    {% if request.user.guides %}
-      <b>This will also permanently delete your following guides:</b>
+    {% for guide in request.user.guide_set.all %}
+      {% if forloop.first %}
+        <b>This will also permanently delete your following guides:</b>
+      {% endif %}
       <ul>
-        {% for guide in request.user.guides %}
-          <li><a href="{% url 'guides:detail' guide.id %}">{{ guide.title }}</a></li>
-        {% endfor %}
+        <li><a href="{% url 'guides:detail' guide.id %}">{{ guide.title }}</a></li>
       </ul>
-    {% endif %}
+    {% endfor %}
     <div class="row align-right">
       <a href="javascript:history.go(-1)" class="button col outline">No, take me back</a>
       <input type="submit" class="button col" value="Yes, delete it" />

--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -6,20 +6,99 @@ from django.test import TestCase
 class AnonymousUserProfilesTests(TestCase):
     """
     Scenario:
-        - Anonymous User
-        - accesses profile detail
+        - Single user in the database
+        - Anonymous User visits the site
+        - accesses profile detail view for known user
+        - accesses profile detail view for unknown user
+        - accesses profile deletion view for known user
+        - accesses profile deletion view for unknown user
     """
 
-    def test_detail_status_404(self):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user('testuser', password='testpassword')
+
+    def test_detail_known_user_status_200(self):
+        resp = self.client.get(reverse("profiles:detail", kwargs={"pk": self.user.id}))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_detail_unknown_user_status_404(self):
         resp = self.client.get(reverse("profiles:detail", kwargs={"pk": 214}))
+        self.assertEqual(resp.status_code, 404)
+
+    def test_delete_known_user_status_403(self):
+        resp = self.client.get(reverse("profiles:delete", kwargs={"pk": self.user.id}))
+        self.assertEqual(resp.status_code, 403)
+
+        resp = self.client.post(reverse("profiles:delete", kwargs={"pk": self.user.id}))
+        self.assertEqual(resp.status_code, 403)
+
+    def test_delete_unknown_user_status_404(self):
+        resp = self.client.get(reverse("profiles:delete", kwargs={"pk": 214}))
+        self.assertEqual(resp.status_code, 404)
+
+        resp = self.client.post(reverse("profiles:delete", kwargs={"pk": 214}))
         self.assertEqual(resp.status_code, 404)
 
 
 class GuestUserProfilesTests(TestCase):
     """
     Scenario:
-        - Guest User
-        - accesses profile detail
+        - Guest User visits the site
+        - Another user in the database
+        - accesses profile detail view for known user
+        - accesses profile detail view for unknown user
+        - accesses profile deletion view for known user
+        - accesses profile deletion view for unknown user
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user('testuser', password='testpassword')
+        cls.original_user = User.objects.create_user('testdatabaseuser', password='testpassword')
+
+    def setUp(self):
+        self.client.force_login(self.user)
+
+    def test_detail_known_users_status_200(self):
+        resp = self.client.get(reverse("profiles:detail", kwargs={"pk": self.user.id}))
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.client.get(reverse("profiles:detail", kwargs={"pk": self.original_user.id}))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_detail_unknown_user_status_404(self):
+        resp = self.client.get(reverse("profiles:detail", kwargs={"pk": 42}))
+        self.assertEqual(resp.status_code, 404)
+
+    def test_get_delete_view_for_self_status_200(self):
+        resp = self.client.get(reverse("profiles:delete", kwargs={"pk": self.user.id}))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_delete_other_user_status_403(self):
+        resp = self.client.get(reverse("profiles:delete", kwargs={"pk": self.original_user.id}))
+        self.assertEqual(resp.status_code, 403)
+
+        resp = self.client.post(reverse("profiles:delete", kwargs={"pk": self.original_user.id}))
+        self.assertEqual(resp.status_code, 403)
+
+    def test_delete_unknown_user_status_404(self):
+        resp = self.client.get(reverse("profiles:delete", kwargs={"pk": 42}))
+        self.assertEqual(resp.status_code, 404)
+
+        resp = self.client.post(reverse("profiles:delete", kwargs={"pk": 42}))
+        self.assertEqual(resp.status_code, 404)
+
+    def test_detail_context(self):
+        resp = self.client.get(reverse("profiles:detail", kwargs={"pk": self.user.id}))
+        self.assertEqual(resp.context["user"], self.user)
+
+
+class UserProfileInteractionsTests(TestCase):
+    """
+    Scenario:
+        - user visits the site
+        - deletes their own profile
     """
 
     @classmethod
@@ -29,10 +108,12 @@ class GuestUserProfilesTests(TestCase):
     def setUp(self):
         self.client.force_login(self.user)
 
-    def test_detail_status_200(self):
-        resp = self.client.get(reverse("profiles:detail", kwargs={"pk": self.user.id}))
+    def test_user_can_delete_own_profile(self):
+        resp = self.client.get(reverse("profiles:delete", kwargs={"pk": self.user.id}))
         self.assertEqual(resp.status_code, 200)
 
-    def test_detail_context(self):
-        resp = self.client.get(reverse("profiles:detail", kwargs={"pk": self.user.id}))
-        self.assertEqual(resp.context["user"], self.user)
+        resp = self.client.post(reverse("profiles:delete", kwargs={"pk": self.user.id}))
+        self.assertEqual(resp.status_code, 302)
+        self.assertRedirects(resp, reverse('home:index'))
+
+        self.assertIsNone(User.objects.filter(id=self.user.id).first())

--- a/profiles/urls.py
+++ b/profiles/urls.py
@@ -1,7 +1,10 @@
 from django.urls import path
 
-from .views import ProfileView
+from . import views
 
 
 app_name = "profiles"
-urlpatterns = [path("<int:pk>", ProfileView.as_view(), name="detail")]
+urlpatterns = [
+    path("<int:pk>", views.ProfileDetailView.as_view(), name="detail"),
+    path("<int:pk>/delete", views.ProfileDeleteView.as_view(), name="delete")
+]

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -1,11 +1,13 @@
 from django.conf import settings
+from django.contrib.auth.mixins import UserPassesTestMixin
 from django.contrib.auth.models import User
+from django.urls import reverse_lazy
 from django.views import generic
 
 from stats.models import RoleMembership
 
 
-class ProfileView(generic.DetailView):
+class ProfileDetailView(generic.DetailView):
     model = User
 
     def get_context_data(self, **kwargs):
@@ -18,3 +20,14 @@ class ProfileView(generic.DetailView):
             role__name="@everyone"
         )
         return context
+
+
+class ProfileDeleteView(UserPassesTestMixin, generic.DeleteView):
+    model = User
+    success_url = reverse_lazy('home:index')
+
+    raise_exception = True
+    permission_denied_message = "You are not allowed to delete a profile that isn't yours."
+
+    def test_func(self):
+        return self.request.user == self.get_object()


### PR DESCRIPTION
This PR adds a view allowing users to delete their own account, as required by [§17 GDPR: Right to erasure ('right to be forgotten')](https://gdpr-info.eu/art-17-gdpr/). It also adds tests for the added view.

The view is not visitable *directly* yet - this will be added to the upcoming profile edit view, which will also be made to comply with the GDPR.