### PR TITLE
Allow editing guides in the Django admin

### DIFF
--- a/guides/admin.py
+++ b/guides/admin.py
@@ -1,1 +1,6 @@
-# Register your models here.
+from django.contrib import admin
+
+from .models import Guide
+
+
+admin.site.register(Guide)


### PR DESCRIPTION
With this PR, it's possible to edit guides in the Django admin, accessible at the `/admin` route.