### PR TITLE
Use `post` instead of `delete` for delete tests.

### DIFF
--- a/guides/tests/test_admin_user_unowned_guide_interactions.py
+++ b/guides/tests/test_admin_user_unowned_guide_interactions.py
@@ -121,11 +121,11 @@ class AdminUserUnownedGuideInteractionsTests(TestCase):
         )
         self.assertEqual(guide_delete_get.status_code, 200)
 
-        guide_delete_delete = self.client.delete(
+        guide_delete_post = self.client.post(
             reverse("guides:delete", kwargs={"pk": self.guide.id})
         )
         self.assertIsNone(Guide.objects.first())
-        self.assertTrue(guide_delete_delete.url.endswith(reverse("guides:index")))
+        self.assertTrue(guide_delete_post.url.endswith(reverse("guides:index")))
 
         guide_index = self.client.get(reverse("guides:index"))
         self.assertSequenceEqual(guide_index.context[INDEX_GUIDE_CONTEXT_NAME], [])

--- a/guides/tests/test_member_user_guide_interactions.py
+++ b/guides/tests/test_member_user_guide_interactions.py
@@ -123,11 +123,11 @@ class MemberUserGuideInteractionsTests(TestCase):
         )
         self.assertEqual(guide_delete_get.status_code, 200)
 
-        guide_delete_delete = self.client.delete(
+        guide_delete_post = self.client.post(
             reverse("guides:delete", kwargs={"pk": guide.id})
         )
-        self.assertEqual(guide_delete_delete.status_code, 302)
-        self.assertTrue(guide_delete_delete.url.endswith(reverse("guides:index")))
+        self.assertEqual(guide_delete_post.status_code, 302)
+        self.assertTrue(guide_delete_post.url.endswith(reverse("guides:index")))
 
         guide_detail_get = self.client.get(
             reverse("guides:detail", kwargs={"pk": guide.id})


### PR DESCRIPTION
For some reason, two tests used the `DELETE` method instead of `POST` to test the deletion view of guides, this PR fixes that.